### PR TITLE
fix CartpolePolicyNet forward float/double correspondence error; auto mkdir if saving dir not exists

### DIFF
--- a/gcsl/examples/cartpole.py
+++ b/gcsl/examples/cartpole.py
@@ -10,8 +10,7 @@ Training in this environment is tricky, since the ends episodes when the pole an
 slightly off from zero. This prevents the agent from gaining experiences far from its
 starting location that is always around the center of the world.
 """
-
-
+import os.path
 from functools import partial
 from pathlib import Path
 from typing import List, Tuple
@@ -88,6 +87,7 @@ class CartpolePolicyNet(torch.nn.Module):
     def forward(self, s, g, h):
         del h
         x = torch.cat((s, g), -1)
+        x = x.float()
         logits = self.logits(x)
         return logits
 
@@ -236,6 +236,8 @@ def train_agent(args):
             postfix_dict["alen"] = alen
             postfix_dict["agm"] = agm
             net.train()
+            if not os.path.isdir('./tmp/'):
+                os.mkdir('./tmp/')
             torch.save(net.state_dict(), f"./tmp/cartpolenet_{e:05d}.pth")
         if e % 100 == 0:
             pbar.set_postfix(postfix_dict)
@@ -281,6 +283,8 @@ def eval_agent(args):
     avg_metric, avg_lens = result[:2]
     print("avg-metric", avg_metric, "avg-len", avg_lens)
     if args.save_gif:
+        if not os.path.isdir('./tmp/'):
+            os.mkdir('./tmp/')
         imageio.mimsave(f"./tmp/{Path(args.weights).stem}.gif", result[-1][::2], fps=60)
 
 


### PR DESCRIPTION
For the first one, the error that has raised in my run is:
 RuntimeError: expected scalar type Long but found Float
After debugging for a while, I found the `forward` function in `CartpolePolicyNet ` concatenate `s` and `g`, which returns a `float64` tensor, while `self.logits` is of dtype `float32`, so I have to convert manually.
FOr the second fix, torch will not create directory for saving weights if it does not exist. 